### PR TITLE
Pre-JWT: req.body

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,14 @@
 const express = require("express");
 const app = express();
 const PORT = process.env.PORT || 3050;
-const cors = require("cors");
-const session = require("express-session");
+const cookieParser = require("cookie-parser"); // not sure if needed now that we aren't using experess-session
 
-app.use(cors()); // allows any origin
+app.use(cookieParser());
+
+// cors setup
+const cors = require("cors");
+const corsoptions = { optionsSuccessStatus: 200, credentials: true };
+app.use(cors(corsoptions)); // allows any origin
 
 // Load in the account routes.
 const accountRoutes = require("./routes/account");

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "bcrypt": "^5.1.0",
         "body-parser": "^1.20.2",
         "connect-session-sequelize": "^7.1.5",
+        "cookie-parser": "^1.4.6",
         "cookie-session": "^2.0.0",
         "cors": "^2.8.5",
         "dotenv": "^16.0.3",
@@ -387,6 +388,26 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -2504,6 +2525,22 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+    },
+    "cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "requires": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+        }
+      }
     },
     "cookie-session": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "bcrypt": "^5.1.0",
     "body-parser": "^1.20.2",
     "connect-session-sequelize": "^7.1.5",
+    "cookie-parser": "^1.4.6",
     "cookie-session": "^2.0.0",
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",

--- a/routes/resourcesRoutes.js
+++ b/routes/resourcesRoutes.js
@@ -25,7 +25,7 @@ router.use(
 
 // CREATE //
 router.post("/create", async (req, res) => {
-  const { name, image } = req.body;
+  const { roomID, name, image } = req.body;
   const resource = await Resources.create({
     name: name,
     image: image,
@@ -33,7 +33,7 @@ router.post("/create", async (req, res) => {
     updatedAt: new Date(),
   });
   const resourcesRooms = await ResourcesRooms.create({
-    roomID: req.session.room.id,
+    roomID: roomID,
     resourceID: resource.dataValues.id,
     createdAt: new Date(),
     updatedAt: new Date(),
@@ -43,10 +43,11 @@ router.post("/create", async (req, res) => {
 // CREATE //
 
 // READ //
-router.get("/view", async (req, res) => {
+router.post("/view", async (req, res) => {
+  const { roomID } = req.body;
   const resourcesInRoom = await ResourcesRooms.findAll({
     where: {
-      roomID: req.session.room.id,
+      roomID: roomID,
     },
   });
 
@@ -63,10 +64,16 @@ router.get("/view", async (req, res) => {
 
 // DESTROY //
 router.delete("/delete", async (req, res) => {
-  const resourceToDel = req.body.id;
+  const { resourceID } = req.body;
   await Resources.destroy({
     where: {
-      id: resourceToDel,
+      id: resourceID,
+    },
+  });
+  // Also need to delete its columns of the ResourcesRooms join table.
+  await ResourcesRooms.destroy({
+    where: {
+      resourceID: resourceID,
     },
   });
   res.send("resource deleted");


### PR DESCRIPTION
JSON web tokens are required because req.session doesn't persist like it does on the backend project. In that project, everything was rendered from the backend and we never really left it. Now, req.session is cleared with every new fetch request. JWT allow us to communicate things like which user is logged in and which room they're in with the backend, which is required for join table management. Right now, we'll use req.body to communicate these things instead of JWTs.